### PR TITLE
Setting Main as Default Branch 

### DIFF
--- a/SET_DEFAULT_BRANCH.md
+++ b/SET_DEFAULT_BRANCH.md
@@ -1,0 +1,124 @@
+# Setting Main as Default Branch - Complete Guide
+
+## ✅ **Local Changes Completed**
+
+The local repository has been updated:
+- ✅ `origin/HEAD` now points to `origin/main`
+- ✅ Currently on `main` branch
+- ✅ Both branches are synchronized
+
+## 🌐 **GitHub Repository Settings**
+
+To complete the default branch change on GitHub:
+
+### **Method 1: GitHub Web Interface (Recommended)**
+
+1. **Go to your repository**: https://github.com/SDG223157/unified_prombank_mcp
+2. **Click Settings tab** (top navigation)
+3. **Scroll down to "Default branch" section**
+4. **Click the switch icon** next to the current default branch
+5. **Select "main"** from the dropdown
+6. **Click "Update"** button
+7. **Confirm the change** in the dialog box
+
+### **Method 2: GitHub CLI (if installed)**
+
+```bash
+# If you have GitHub CLI installed
+gh repo edit --default-branch main
+```
+
+### **Method 3: GitHub API (Advanced)**
+
+```bash
+# Using curl with GitHub API
+curl -X PATCH \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token YOUR_GITHUB_TOKEN" \
+  https://api.github.com/repos/SDG223157/unified_prombank_mcp \
+  -d '{"default_branch":"main"}'
+```
+
+---
+
+## 🔍 **Verification Steps**
+
+After changing on GitHub, verify the change:
+
+### **1. Check GitHub Repository**
+- Visit: https://github.com/SDG223157/unified_prombank_mcp
+- The main branch should be shown by default
+- Branch dropdown should show "main" as default
+
+### **2. Test New Clone**
+```bash
+# Test in a different directory
+git clone https://github.com/SDG223157/unified_prombank_mcp test-clone
+cd test-clone
+git branch  # Should show "main" as current branch
+```
+
+### **3. Check Remote HEAD**
+```bash
+git ls-remote --symref origin HEAD
+# Should show: ref: refs/heads/main	HEAD
+```
+
+---
+
+## 📋 **Current Status**
+
+✅ **Local Repository:**
+- Default branch: main
+- Remote HEAD: origin/main
+- Current branch: main
+
+⏳ **GitHub Repository:**
+- Needs manual update via GitHub web interface
+- Will show main as default after update
+
+---
+
+## 🎯 **Why This Change?**
+
+**Benefits of main as default:**
+- ✅ **Industry standard** - main is the modern default branch name
+- ✅ **Feature complete** - main now has all latest features from unified-clean
+- ✅ **Production ready** - includes all security fixes and enhancements
+- ✅ **Comprehensive documentation** - all guides and tools included
+- ✅ **8 MCP tools** - complete functionality
+
+**Previous state:**
+- unified-clean was default (development branch)
+- main was outdated (legacy version)
+
+**Current state:**
+- Both branches synchronized
+- main has all latest features
+- Ready for production use
+
+---
+
+## 🚀 **Next Steps**
+
+1. **Update GitHub default branch** (via web interface)
+2. **Consider branch strategy:**
+   - Keep `main` for stable releases
+   - Use `unified-clean` or create `develop` for ongoing development
+   - Create feature branches for new features
+
+3. **Update documentation** if needed
+4. **Notify team members** about the default branch change
+
+---
+
+## ⚠️ **Important Notes**
+
+- **Existing clones** will still use their original default branch
+- **New clones** will automatically use main after GitHub update
+- **CI/CD pipelines** may need updating if they reference the old default
+- **Protected branch rules** may need to be updated
+
+---
+
+**Ready to complete the default branch change on GitHub!** 🎉


### PR DESCRIPTION
📋 Documentation:
- Complete guide for changing default branch from unified-clean to main
- Instructions for GitHub web interface, CLI, and API methods
- Verification steps and current status
- Benefits of using main as default branch

✅ Local Changes Completed:
- Remote HEAD now points to origin/main
- Currently on main branch
- Both branches synchronized with all latest features

🌐 Next Step:
- Update GitHub repository settings via web interface
- Will complete the default branch change process